### PR TITLE
always pull latest version of noalbs2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN set -xe; \
 
 # NOALBS 2
 #
-ARG NOALBS_VERSION=v2.5.5
+ARG NOALBS_VERSION=latest
 RUN set -xe; \
     git clone https://github.com/715209/nginx-obs-automatic-low-bitrate-switching /app; \
     cd /app; \


### PR DESCRIPTION
no more hardcoded version number